### PR TITLE
Adds batch submit URL and ability to pass in reduction script/arguments/user id/description

### DIFF
--- a/autoreduce_rest_api/runs/urls.py
+++ b/autoreduce_rest_api/runs/urls.py
@@ -5,8 +5,7 @@ from autoreduce_rest_api.runs import views
 app_name = "runs"
 
 urlpatterns = [
-    path('runs/<str:instrument>/<int:start>', views.ManageRuns.as_view(), name="manage"),
-    path('runs/<str:instrument>/<int:start>/<int:end>', views.ManageRuns.as_view(), name="manage"),
+    path('runs/<str:instrument>', views.ManageRuns.as_view(), name="manage"),
     path('runs/batch/<str:instrument>', views.BatchSubmit.as_view(), name="batch"),
     path('runs/batch/<str:instrument>/<int:pk>', views.BatchSubmit.as_view(), name="batch"),
 ]

--- a/autoreduce_rest_api/runs/urls.py
+++ b/autoreduce_rest_api/runs/urls.py
@@ -7,4 +7,5 @@ app_name = "runs"
 urlpatterns = [
     path('runs/<str:instrument>/<int:start>', views.ManageRuns.as_view(), name="manage"),
     path('runs/<str:instrument>/<int:start>/<int:end>', views.ManageRuns.as_view(), name="manage"),
+    path('runs/batch/<str:instrument>', views.BatchSubmit.as_view(), name="batch"),
 ]

--- a/autoreduce_rest_api/runs/urls.py
+++ b/autoreduce_rest_api/runs/urls.py
@@ -8,4 +8,5 @@ urlpatterns = [
     path('runs/<str:instrument>/<int:start>', views.ManageRuns.as_view(), name="manage"),
     path('runs/<str:instrument>/<int:start>/<int:end>', views.ManageRuns.as_view(), name="manage"),
     path('runs/batch/<str:instrument>', views.BatchSubmit.as_view(), name="batch"),
+    path('runs/batch/<str:instrument>/<int:pk>', views.BatchSubmit.as_view(), name="batch"),
 ]

--- a/autoreduce_rest_api/runs/views.py
+++ b/autoreduce_rest_api/runs/views.py
@@ -58,3 +58,10 @@ class BatchSubmit(APIView):
             })
         except RuntimeError as err:
             return JsonResponse({"message": str(err)}, status=400)
+
+    def delete(self, request, instrument: str, pk: int):
+        """Deletes the batch reduction"""
+        try:
+            return JsonResponse({"removed_runs": remove_main(instrument, pk, delete_all_versions=True, no_input=True)})
+        except RuntimeError as err:
+            return JsonResponse({"message": str(err)}, status=400)

--- a/autoreduce_rest_api/runs/views.py
+++ b/autoreduce_rest_api/runs/views.py
@@ -8,6 +8,12 @@ from autoreduce_scripts.manual_operations.manual_batch_submit import main as sub
 from autoreduce_scripts.manual_operations.manual_remove import main as remove_main
 
 
+def get_common_args_from_request(request):
+    """Gets common arguments that are used in all POST views"""
+    return (request.data.get("reduction_arguments", {}), request.data.get("user_id",
+                                                                          -1), request.data.get("description", ""))
+
+
 # pylint:disable=no-self-use
 class ManageRuns(APIView):
     """
@@ -44,12 +50,11 @@ class BatchSubmit(APIView):
         """Submits the runs as a batch reduction"""
         if "runs" not in request.data:
             return JsonResponse({"error": "No 'runs' key specified"}, status=400)
-        if "reduction_arguments" not in request.data:
-            reduction_arguments = {}
-        else:
-            reduction_arguments = request.data["reduction_arguments"]
+        reduction_arguments, user_id, description = get_common_args_from_request(request)
         try:
-            return JsonResponse(
-                {"submitted_runs": submit_batch_main(instrument, request.data["runs"], reduction_arguments)})
+            return JsonResponse({
+                "submitted_runs":
+                submit_batch_main(instrument, request.data["runs"], reduction_arguments, user_id, description)
+            })
         except RuntimeError as err:
             return JsonResponse({"message": str(err)}, status=400)

--- a/autoreduce_rest_api/runs/views.py
+++ b/autoreduce_rest_api/runs/views.py
@@ -59,9 +59,11 @@ class BatchSubmit(APIView):
         except RuntimeError as err:
             return JsonResponse({"message": str(err)}, status=400)
 
-    def delete(self, request, instrument: str, pk: int):
+    # pylint:disable=invalid-name
+    def delete(self, _, instrument: str, pk: int):
         """Deletes the batch reduction"""
         try:
-            return JsonResponse({"removed_runs": remove_main(instrument, pk, delete_all_versions=True, no_input=True)})
+            return JsonResponse(
+                {"removed_runs": remove_main(instrument, pk, delete_all_versions=True, no_input=True, batch=True)})
         except RuntimeError as err:
             return JsonResponse({"message": str(err)}, status=400)

--- a/setup.py
+++ b/setup.py
@@ -8,11 +8,11 @@ for more details
 from setuptools import setup, find_packages
 
 setup(name="autoreduce_rest_api",
-      version="22.0.0.dev8",
+      version="22.0.0.dev9",
       description="ISIS Autoreduction Runs REST API",
       author="ISIS Autoreduction Team",
       url="https://github.com/ISISScientificComputing/autoreduce/",
-      install_requires=["autoreduce_scripts==22.0.0.dev18", "django==3.2.8", "djangorestframework==3.12.4"],
+      install_requires=["autoreduce_scripts==22.0.0.dev20", "django==3.2.8", "djangorestframework==3.12.4"],
       packages=find_packages(),
       entry_points={"console_scripts": ["autoreduce-rest-api-manage = autoreduce_rest_api.manage:main"]},
       classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(name="autoreduce_rest_api",
       description="ISIS Autoreduction Runs REST API",
       author="ISIS Autoreduction Team",
       url="https://github.com/ISISScientificComputing/autoreduce/",
-      install_requires=["autoreduce_scripts==22.0.0.dev17", "django==3.2.8", "djangorestframework==3.12.4"],
+      install_requires=["autoreduce_scripts==22.0.0.dev18", "django==3.2.8", "djangorestframework==3.12.4"],
       packages=find_packages(),
       entry_points={"console_scripts": ["autoreduce-rest-api-manage = autoreduce_rest_api.manage:main"]},
       classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(name="autoreduce_rest_api",
       description="ISIS Autoreduction Runs REST API",
       author="ISIS Autoreduction Team",
       url="https://github.com/ISISScientificComputing/autoreduce/",
-      install_requires=["autoreduce_scripts==22.0.0.dev15", "django==3.2.6", "djangorestframework==3.12.4"],
+      install_requires=["autoreduce_scripts==22.0.0.dev17", "django==3.2.8", "djangorestframework==3.12.4"],
       packages=find_packages(),
       entry_points={"console_scripts": ["autoreduce-rest-api-manage = autoreduce_rest_api.manage:main"]},
       classifiers=[


### PR DESCRIPTION
### Summary of work
Adds batch submit URL for submitting new batch runs & reruns.

Adds ability to pass in reduction script/arguments/user id/description.

Makes `submit_run` suitable for sending re-runs from the frontend.

### How to test your work
<!---This can be a link to the---> 

### Additional comments
<!---Anything else: e.g. was the estimate reasonable for this issue?---> 

Fixes #xyz


**Before merging ensure the release notes have been updated**